### PR TITLE
Fix removed @*INC

### DIFF
--- a/t/01-encoding.t
+++ b/t/01-encoding.t
@@ -1,6 +1,6 @@
 use v6;
 
-#BEGIN { @*INC.unshift: './lib'; }
+#use lib 'lib';
 
 use Test;
 use Netstring;

--- a/t/02-decoding.t
+++ b/t/02-decoding.t
@@ -1,6 +1,6 @@
 use v6;
 
-#BEGIN { @*INC.unshift: './lib'; }
+#use lib 'lib';
 
 use Test;
 use Netstring;


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.